### PR TITLE
Resolve Gradle Configuration Caching Issues When Executing AsciidoctorTask

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version = 4.0.2
+version = 4.0.2-local
 group = org.asciidoctor
 
 copyrightYear       = 2013-2024

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -110,7 +110,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
 
     protected final MapProperty<String, Object> optionsProperty = project.objects.mapProperty(String, Object)
     protected final MapProperty<String, Object> attributesProperty = project.objects.mapProperty(String, Object)
-    public final ListProperty<AsciidoctorAttributeProvider> attributeProviderProperty = project.objects.listProperty(AsciidoctorAttributeProvider)
+    protected final ListProperty<AsciidoctorAttributeProvider> attributeProviderProperty = project.objects.listProperty(AsciidoctorAttributeProvider)
     protected FileCollection configurationsFileCollection
     protected final ListProperty<Pattern> fatalWarningsProperty = project.objects.listProperty(Pattern)
     protected final ListProperty<String> requiresProperty = project.objects.listProperty(String)

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -93,7 +93,6 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
     public final static Severity WARN = Severity.WARN
     public final static Severity INFO = Severity.INFO
 
-    protected final AsciidoctorJExtension asciidoctorj
     private ExecutionMode inProcess
     private Severity failureLevel = Severity.FATAL
     private final List<Object> asciidocConfigurations = []

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -519,12 +519,13 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
 
         def asciidoctorj = extensions.create(AsciidoctorJExtension.NAME, AsciidoctorJExtension, this)
         this.optionsProperty.set(asciidoctorj.options)
+        this.safeModeProperty.set(asciidoctorj.getSafeMode())
         this.attributesProperty.set(asciidoctorj.attributes)
         this.attributeProviderProperty.set(asciidoctorj.attributeProviders)
         this.configurationsFileCollection = getConfigurations(asciidoctorj)
         this.fatalWarningsProperty.set(asciidoctorj.fatalWarnings)
         this.requiresProperty.set(asciidoctorj.requires)
-        this.logLevelProperty.set(asciidoctorj.logLevel)
+        this.logLevelProperty.set(asciidoctorj.getLogLevel() != null ? asciidoctorj.getLogLevel() : LogLevel.INFO)
         this.docExtensionsProperty.set(asciidoctorj.docExtensions)
 
         this.projectDir = project.projectDir

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -814,13 +814,6 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
         }
     }
 
-    // TODO: Try to do this without a detached configuration
-//    private FileCollection jrubyLessConfiguration(List<Dependency> deps) {
-//        Configuration cfg = detachedConfigurationCreator.apply(deps)
-//        asciidoctorj.loadJRubyResolutionStrategy(cfg)
-//        cfg
-//    }
-
     private Map<String, Object> preparePreserialisedAttributes(final File workingSourceDir, Optional<String> lang) {
         prepareAttributes(
                 projectOperations.stringTools,

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -106,7 +106,6 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
     private final File rootDir
     private final File projectDir
     private final File execConfigurationDataFile
-//    private final Function<List<Dependency>, Configuration> detachedConfigurationCreator
     private final Property<FileCollection> jvmClasspath
     private final List<Provider<File>> gemJarProviders = []
 

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -49,7 +49,6 @@ import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
@@ -112,7 +111,6 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
     protected final MapProperty<String, Object> optionsProperty = project.objects.mapProperty(String, Object)
     protected final MapProperty<String, Object> attributesProperty = project.objects.mapProperty(String, Object)
     public final ListProperty<AsciidoctorAttributeProvider> attributeProviderProperty = project.objects.listProperty(AsciidoctorAttributeProvider)
-    @Classpath
     protected FileCollection configurationsFileCollection
     protected final ListProperty<Pattern> fatalWarningsProperty = project.objects.listProperty(Pattern)
     protected final ListProperty<String> requiresProperty = project.objects.listProperty(String)

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -108,16 +108,16 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
     private final Property<FileCollection> jvmClasspath
     private final List<Provider<File>> gemJarProviders = []
 
-    protected final MapProperty<String, Object> optionsProperty = project.objects.mapProperty(String, Object)
-    protected final MapProperty<String, Object> attributesProperty = project.objects.mapProperty(String, Object)
-    protected final ListProperty<AsciidoctorAttributeProvider> attributeProviderProperty = project.objects
+    private final MapProperty<String, Object> optionsProperty = project.objects.mapProperty(String, Object)
+    private final MapProperty<String, Object> attributesProperty = project.objects.mapProperty(String, Object)
+    private final ListProperty<AsciidoctorAttributeProvider> attributeProviderProperty = project.objects
             .listProperty(AsciidoctorAttributeProvider)
-    protected FileCollection configurationsFileCollection
-    protected final ListProperty<Pattern> fatalWarningsProperty = project.objects.listProperty(Pattern)
-    protected final ListProperty<String> requiresProperty = project.objects.listProperty(String)
-    protected final Property<LogLevel> logLevelProperty = project.objects.property(LogLevel)
-    protected final Property<SafeMode> safeModeProperty = project.objects.property(SafeMode)
-    protected final ListProperty<Object> docExtensionsProperty = project.objects.listProperty(Object)
+    private FileCollection configurationsFileCollection
+    private final ListProperty<Pattern> fatalWarningsProperty = project.objects.listProperty(Pattern)
+    private final ListProperty<String> requiresProperty = project.objects.listProperty(String)
+    private final Property<LogLevel> logLevelProperty = project.objects.property(LogLevel)
+    private final Property<SafeMode> safeModeProperty = project.objects.property(SafeMode)
+    private final ListProperty<Object> docExtensionsProperty = project.objects.listProperty(Object)
 
     private final Provider<FileCollection> jrubyLessDependenciesProvider = project.provider {
         List<Dependency> deps = this.docExtensionsProperty.get().findAll {

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -401,7 +401,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
      */
     @Override
     Set<Configuration> getReportableConfigurations() {
-        (/*[asciidoctorj.configuration] +*/ projectOperations.configurations.asConfigurations(asciidocConfigurations))
+        ([getAsciidoctorJExtension().configuration] + projectOperations.configurations.asConfigurations(asciidocConfigurations))
                 .toSet()
     }
 

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -334,8 +334,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
      * @param m Map with new options
      */
     void attributes(Map m) {
-        attributesProperty.set(attributesProperty.get() + m)
-
+        attributesProperty.putAll(m)
     }
 
     /** Additional providers of attributes.
@@ -537,12 +536,6 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
         this.rootDir = project.rootDir
         this.jvmClasspath = project.objects.property(FileCollection)
         this.execConfigurationDataFile = getExecConfigurationDataFile(this)
-//        this.detachedConfigurationCreator = { ConfigurationContainer c, List<Dependency> deps ->
-//            final cfg = c.detachedConfiguration(deps.toArray() as Dependency[])
-//            cfg.canBeConsumed = false
-//            cfg.canBeResolved = true
-//            cfg
-//        }.curry(project.configurations) as Function<List<Dependency>, Configuration>
 
         inputs.files { gemJarProviders }.withPathSensitivity(RELATIVE)
         inputs.property 'backends', { -> backends() }

--- a/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
+++ b/jvm/src/main/groovy/org/asciidoctor/gradle/jvm/AbstractAsciidoctorTask.groovy
@@ -57,7 +57,6 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.process.JavaForkOptions
 import org.gradle.workers.WorkerExecutor
-import org.jcodings.util.Hash
 import org.ysb33r.grolifant.api.core.LegacyLevel
 import org.ysb33r.grolifant.api.core.jvm.ExecutionMode
 import org.ysb33r.grolifant.api.core.jvm.JavaForkOptionsWithEnvProvider
@@ -342,7 +341,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
      */
     @Internal
     List<AsciidoctorAttributeProvider> getAttributeProviders() {
-        attributeProviderProperty.get()
+        attributeProviderProperty.get().stream().collect(Collectors.toList())
     }
 
     /** Returns all of the specified configurations as a collections of files.
@@ -539,8 +538,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
             cfg
         }.curry(project.configurations) as Function<List<Dependency>, Configuration>
 
-        inputs.files(asciidoctorj.configuration)
-//        inputs.files { gemJarProviders }.withPathSensitivity(RELATIVE)
+        inputs.files { gemJarProviders }.withPathSensitivity(RELATIVE)
         inputs.property 'backends', { -> backends() }
         inputs.property 'asciidoctorj-version', { -> asciidoctorj.version }
         inputs.property 'jruby-version', { -> asciidoctorj.jrubyVersion ?: '' }
@@ -645,9 +643,9 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
                 ),
                 backendName: backendName,
                 logDocuments: logDocuments,
-                fatalMessagePatterns: fatalWarningsProperty.get(),
+                fatalMessagePatterns: fatalWarningsProperty.get().stream().collect(Collectors.toList()),
                 asciidoctorExtensions: serializableAsciidoctorJExtensions,
-                requires: requiresProperty.get(),
+                requires: requiresProperty.get().stream().collect(Collectors.toList()),
                 copyResources: copyResources.present &&
                         (copyResources.get().empty || backendName in copyResources.get()),
                 executorLogLevel: ExecutorUtils.getExecutorLogLevel(logLevelProperty.get()),
@@ -661,7 +659,7 @@ class AbstractAsciidoctorTask extends AbstractJvmModelExecTask<AsciidoctorJvmExe
      */
     @Internal
     protected List<Object> getAsciidoctorJExtensions() {
-        docExtensionsProperty.get()
+        docExtensionsProperty.get().stream().collect(Collectors.toList())
     }
 
     @Nested


### PR DESCRIPTION
Fixes the Gradle configuration caching issues originating from this project when executing `org.asciidoctor.gradle.jvm.AsciidoctorTask`. There are some remaining issues, but those are caused by the grolifant library.

The configuration caching issues in this project were primarily tasks referencing [types incompatible with configuration caching](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types). The references to these types were mostly held by `AsciidoctorJExtension`, which `AbstractAsciidoctorTask` held a reference to. To resolve this, the individual properties of `AsciidoctorJExtension` were moved directly to `AbstractAsciidoctorTask` in a configuration cache-compatible way. No input annotations were added to these properties to maintain parity with the current task behavior. The property values are wired from the extension to the task properties in `AbstractAsciidoctorTask`'s constructor. In such cases where providers are used and referencing `AsciidoctorJExtension` is required, an `@Internal` getter is used to access the `AsciidoctorJExtension` instance. This `@Internal` getter prevents Gradle from attempting to serialize `AsciidoctorJExtension` to the configuration cache.

One behavioral change is that `AbstractAsciidoctorTask` no longer has the ability to write back to `AsciidoctorJExtension` since the reference from the task to the extension was removed. The methods that allowed this were updated to write to the properties that now reside in the task. As it stands I'm not sure what the full impact of that change is. Additionally, since this reference was removed, some methods were copied from `AsciidoctorJExtension` to `AbstractAsciidoctorTask` where needed. This should probably be done in a better way than just copying the methods, but I would like to get input first since this changes the relationship between the extension and the task.

The remaining configuration caching issues are shown in the following report
<img width="1633" alt="image" src="https://github.com/tylerbertrand/asciidoctor-gradle-plugin/assets/121591679/822713be-88aa-440b-b595-5c94d40bb959">
